### PR TITLE
Delete local.properties

### DIFF
--- a/local.properties
+++ b/local.properties
@@ -1,8 +1,0 @@
-## This file must *NOT* be checked into Version Control Systems,
-# as it contains information specific to your local configuration.
-#
-# Location of the SDK. This is only used by Gradle.
-# For customization when using a Version Control System, please read the
-# header note.
-#Fri Dec 20 11:15:53 CST 2019
-sdk.dir=D\:\\Android\\Sdk


### PR DESCRIPTION
It should removed from repository, because android sdk is located in other paths on other machines